### PR TITLE
Remove "Current Week" Section from Facility Pages

### DIFF
--- a/frontend/src/pages/Dining.jsx
+++ b/frontend/src/pages/Dining.jsx
@@ -65,17 +65,6 @@ const Dining = () => {
       <p className="section-subtitle">
         Campus dining options, coffee shops, and food courts
       </p>
-      <div className="week-context-card">
-        <div className="week-context-header">
-          <span className="week-context-label">CURRENT WEEK</span>
-        </div>
-        <div className="week-context-date">
-          {formatWeekRange()}
-        </div>
-        <div className="week-context-status">
-          Last updated: {getRelativeUpdateTime(lastUpdated)}
-        </div>
-      </div>
       
       <div className="facility-section">
         <div className="facility-tabs">

--- a/frontend/src/pages/Gym.jsx
+++ b/frontend/src/pages/Gym.jsx
@@ -64,17 +64,6 @@ const Gym = () => {
       <p className="section-subtitle">
         Fitness facilities, swimming, climbing, and recreational activities
       </p>
-      <div className="week-context-card">
-        <div className="week-context-header">
-          <span className="week-context-label">CURRENT WEEK</span>
-        </div>
-        <div className="week-context-date">
-          {formatWeekRange()}
-        </div>
-        <div className="week-context-status">
-          Last updated: {getRelativeUpdateTime(lastUpdated)}
-        </div>
-      </div>
       
       <div className="facility-section">
         <div className="facility-tabs">

--- a/frontend/src/pages/Library.jsx
+++ b/frontend/src/pages/Library.jsx
@@ -59,17 +59,6 @@ const Library = () => {
       <p className="section-subtitle">
         Academic resources, research support, and study spaces
       </p>
-      <div className="week-context-card">
-        <div className="week-context-header">
-          <span className="week-context-label">CURRENT WEEK</span>
-        </div>
-        <div className="week-context-date">
-          {formatWeekRange()}
-        </div>
-        <div className="week-context-status">
-          Last updated: {getRelativeUpdateTime(lastUpdated)}
-        </div>
-      </div>
       
       <div className="facility-section">
         <div className="facility-tabs">


### PR DESCRIPTION
Summary:
- Removed the "Current Week" section (which displayed the current week range and last updated time) from the Library, Gym (Recreation Center), and Dining pages.

Details:
- Deleted the <div className="week-context-card">...</div> block from each page.
- The pages now flow directly from their subtitle to the facility tabs/sections, resulting in a cleaner and less cluttered UI.

Motivation:
- The "Current Week" and "Last Updated" information was deemed unnecessary for users.
- Improves visual clarity and focuses attention on the facility hours and navigation.

No changes were made to the backend or API.