### PR TITLE
Remove unused imports and variables after "Current Week" section removal

### DIFF
--- a/frontend/src/pages/Dining.jsx
+++ b/frontend/src/pages/Dining.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { facilityAPI } from '../services/api.js';
-import { parseMultipleTimeRanges, formatWeekRange, formatDayWithDate, isClosedTime, normalizeTimeFormat, getRelativeUpdateTime } from '../utils/timeUtils.js';
+import { parseMultipleTimeRanges, formatDayWithDate, isClosedTime, normalizeTimeFormat } from '../utils/timeUtils.js';
 
 const Dining = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [hours, setHours] = useState(null);
-  const [lastUpdated, setLastUpdated] = useState(null);
   const [activeTab, setActiveTab] = useState(null);
 
   useEffect(() => {
@@ -16,7 +15,6 @@ const Dining = () => {
         const data = await facilityAPI.getDiningHours();
         if (data && data.sections) {
           setHours(data.sections);
-          setLastUpdated(data.last_updated);
           // Set initial active tab to first facility
           const facilities = Object.keys(data.sections);
           if (facilities.length > 0) {

--- a/frontend/src/pages/Gym.jsx
+++ b/frontend/src/pages/Gym.jsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { facilityAPI } from '../services/api.js';
-import { parseMultipleTimeRanges, formatWeekRange, formatDayWithDate, isClosedTime, getRelativeUpdateTime } from '../utils/timeUtils.js';
+import { parseMultipleTimeRanges, formatDayWithDate, isClosedTime } from '../utils/timeUtils.js';
 
 const Gym = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('CHP (Fitness Center)');
   const [facilities, setFacilities] = useState(null);
-  const [lastUpdated, setLastUpdated] = useState(null);
 
   useEffect(() => {
     const fetchRecreationHours = async () => {
@@ -16,7 +15,6 @@ const Gym = () => {
         const data = await facilityAPI.getRecreationHours();
         if (data && data.sections) {
           setFacilities(data.sections);
-          setLastUpdated(data.last_updated);
         } else {
           throw new Error('No recreation hours data available');
         }

--- a/frontend/src/pages/Library.jsx
+++ b/frontend/src/pages/Library.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { facilityAPI } from '../services/api.js';
-import { parseMultipleTimeRanges, formatWeekRange, formatDayWithDate, isClosedTime, getRelativeUpdateTime } from '../utils/timeUtils.js';
+import { parseMultipleTimeRanges, formatDayWithDate, isClosedTime } from '../utils/timeUtils.js';
 
 const Library = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [hours, setHours] = useState(null);
-  const [lastUpdated, setLastUpdated] = useState(null);
   const [activeTab, setActiveTab] = useState('main-library');
 
   useEffect(() => {
@@ -16,7 +15,6 @@ const Library = () => {
         const data = await facilityAPI.getLibraryHours();
         if (data && data.sections) {
           setHours(data.sections);
-          setLastUpdated(data.last_updated);
         } else {
           throw new Error('No library hours data available');
         }


### PR DESCRIPTION
- Cleaned up unused imports and state in Library, Gym, and Dining pages to resolve ESLint errors.