### PR TITLE
Fix-hover state persistence on Ramtram page and hours box color change for hovering

### DIFF
--- a/frontend/src/styles/Layout.css
+++ b/frontend/src/styles/Layout.css
@@ -651,11 +651,24 @@ body {
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.hours-row.clickable:hover {
-  background: var(--asu-blue-light);
-  border-color: var(--asu-blue-light);
-  transform: translateX(4px);
-  box-shadow: 0 4px 12px rgba(0, 63, 127, 0.15);
+.hours-row.clickable:hover .hours-time {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Only apply hover effects on devices that support hover (not touch devices) */
+@media (hover: hover) {
+  .hours-row.clickable:hover {
+    background: var(--asu-blue-light);
+    border-color: var(--asu-blue-light);
+    transform: translateX(4px);
+    box-shadow: 0 4px 12px rgba(0, 63, 127, 0.15);
+  }
+
+  .hours-row.clickable:hover .hours-time {
+    color: white;
+    background: rgba(255, 255, 255, 0.1);
+    border-color: white;
+  }
 }
 
 .hours-row.selected {


### PR DESCRIPTION
hover state persistence when clicking the row to close it on the Ramtram page in the mobile version and hours box color change for hovering